### PR TITLE
fix: Configure Vite for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@
   import path from 'path';
 
   export default defineConfig({
+    base: '/aima2/',
     plugins: [react()],
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
@@ -51,7 +52,7 @@
     },
     build: {
       target: 'esnext',
-      outDir: 'build',
+      outDir: 'dist',
     },
     server: {
       port: 3000,


### PR DESCRIPTION
The website was showing a blank page because the Vite build was not configured for deployment to a subdirectory on GitHub Pages.

This commit makes the following changes to `vite.config.ts`:
- Sets the `base` option to '/aima2/' to ensure asset paths are generated correctly.
- Changes the `outDir` from 'build' to 'dist' to follow convention.

With these changes, running `npm run build` will produce a `dist` directory that can be correctly deployed to GitHub Pages.