### PR TITLE
fix: Remove invalid jsx prop from style tag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-white relative overflow-x-hidden">
       {/* Global Performance Optimizations */}
-      <style jsx global>{`
+      <style>{`
         * {
           backface-visibility: hidden;
           -webkit-backface-visibility: hidden;


### PR DESCRIPTION
The application was showing a blank white page because of a runtime error. The error was caused by the use of a `jsx` prop on a `<style>` tag in `App.tsx`. This syntax is specific to the `styled-jsx` library, which was not installed as a dependency in this Vite project.

This commit removes the `jsx` and `global` props from the `<style>` tag, turning it into a standard HTML style element that React can render without issues. This resolves the runtime crash and should allow the application to render correctly.