### PR TITLE
fix: Remove next-themes dependency to prevent crash

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useTheme } from "next-themes@0.4.6";
 import { Toaster as Sonner, ToasterProps } from "sonner@2.0.3";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={"system" as ToasterProps["theme"]}
       className="toaster group"
       style={
         {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,6 @@
         'react-resizable-panels@2.1.7': 'react-resizable-panels',
         'react-hook-form@7.55.0': 'react-hook-form',
         'react-day-picker@8.10.1': 'react-day-picker',
-        'next-themes@0.4.6': 'next-themes',
         'lucide-react@0.487.0': 'lucide-react',
         'input-otp@1.4.2': 'input-otp',
         'embla-carousel-react@8.6.0': 'embla-carousel-react',


### PR DESCRIPTION
The application continued to show a blank page after the previous fix. Further investigation revealed a second runtime error caused by the `next-themes` package.

This package is designed for Next.js and requires a `ThemeProvider` to be present in the application tree. The `useTheme` hook was being called in `src/components/ui/sonner.tsx` without this provider, causing the application to crash.

This commit removes the dependency on `next-themes` entirely:
- The `useTheme` hook has been removed from `sonner.tsx` and the theme is now hardcoded to "system".
- The unused alias for `next-themes` has been removed from `vite.config.ts`.

This second fix should resolve the remaining runtime error and allow the application to render correctly.